### PR TITLE
Support configurable runtime directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The easiest way to install HYMET is through Bioconda:
 conda install -c bioconda hymet
 ```
 
-After installation, you will need to download the reference databases as described in the [Reference Sketched Databases](#reference-sketched-databases) section.
+After installation, you will need to download the reference databases as described in the [Reference Sketched Databases](#reference-sketched-databases) section. The executable `hymet-config` and the main pipeline command `hymet` can now be executed from any directory; runtime data are stored in a writable location (see [Runtime Directories](#runtime-directories)).
 
 ### 2. Clone the Repository
 
@@ -112,6 +112,17 @@ If installed via Conda, you can use:
 hymet-config
 hymet
 ```
+
+Both commands use `~/.hymet` as the default working directory and will create it automatically if it does not exist. You can change the location by defining the `HYMET_WORKDIR` environment variable before invoking either command.
+
+## Runtime Directories
+
+HYMET separates immutable resources from user-specific data so that the Conda installation can be used without cloning the repository. The following environment variables are available:
+
+- **`HYMET_WORKDIR`** – Optional. Overrides the default working directory (`~/.hymet`). This directory will contain the downloaded taxonomy files, cached genomes, and pipeline outputs. Ensure the location is writable.
+- **`HYMET_RESOURCES`** – Optional. Overrides the directory where HYMET looks for bundled helper scripts. Normally this is detected automatically from the Conda installation or the cloned repository and should not need to be set unless the package is relocated.
+
+When running from a cloned repository, both variables are optional and the defaults continue to work.
 
 ## Reference Sketched Databases
 

--- a/config.pl
+++ b/config.pl
@@ -1,41 +1,63 @@
 #!/usr/bin/perl
 use strict;
 use warnings;
+use Cwd qw(abs_path);
 use FindBin qw($Bin);
-use File::Spec::Functions qw(catdir catfile);
+use File::Path qw(make_path);
+use File::Spec::Functions qw(catdir catfile rel2abs);
 
-# Use the directory containing this script as the base path
-my $base_path = $Bin;
+sub find_resource_base {
+    my @candidates;
 
-# Define the necessary directories
-my $taxonomy_files_dir = catdir($base_path, 'taxonomy_files');
-my $scripts_dir = catdir($base_path, 'scripts');
-my $data_dir = catdir($base_path, 'data');
-my $output_dir = catdir($base_path, 'output');
-my $cache_dir = catdir($base_path, 'cache');
+    push @candidates, $ENV{HYMET_RESOURCES} if $ENV{HYMET_RESOURCES};
 
-# Ensure the data directory exists for downstream scripts
-mkdir $data_dir unless -d $data_dir;
-mkdir $output_dir unless -d $output_dir;
-mkdir $cache_dir unless -d $cache_dir;
+    my $bin_path = abs_path($Bin);
+    push @candidates, $bin_path if defined $bin_path;
 
-# Create directories if they don't exist
-mkdir $taxonomy_files_dir unless -d $taxonomy_files_dir;
-mkdir $scripts_dir unless -d $scripts_dir;
+    if (defined $bin_path) {
+        my $prefix = abs_path(catdir($bin_path, '..'));
+        if (defined $prefix) {
+            push @candidates, catdir($prefix, 'share', 'hymet');
+            push @candidates, catdir($prefix, 'share', 'HYMET');
+        }
+    }
 
-# URL for taxonomy files
+    for my $candidate (@candidates) {
+        next unless defined $candidate;
+        my $scripts_path = catdir($candidate, 'scripts');
+        my $taxonomy_script = catfile($scripts_path, 'taxonomy_hierarchy.py');
+        if (-f $taxonomy_script) {
+            return ($candidate, $scripts_path);
+        }
+    }
+
+    die "Unable to locate HYMET resources. Set the HYMET_RESOURCES environment variable to the directory containing the scripts folder.\n";
+}
+
+my ($resource_base, $scripts_dir) = find_resource_base();
+
+my $home = $ENV{HOME} // '.';
+my $work_dir = $ENV{HYMET_WORKDIR} // catdir($home, '.hymet');
+$work_dir = rel2abs($work_dir);
+
+my $taxonomy_files_dir = catdir($work_dir, 'taxonomy_files');
+my $data_dir = catdir($work_dir, 'data');
+my $output_dir = catdir($work_dir, 'output');
+my $cache_dir = catdir($work_dir, 'cache');
+
+make_path($taxonomy_files_dir, $data_dir, $output_dir, $cache_dir);
+
+print "Using work directory: $work_dir\n";
+
 my $taxdmp_url = "ftp://ftp.ncbi.nlm.nih.gov/pub/taxonomy/taxdmp.zip";
 
-# Download taxonomy files
 print "Downloading taxonomy files...\n";
 my $taxdmp_zip = catfile($taxonomy_files_dir, 'taxdmp.zip');
 system('wget', '-q', '-O', $taxdmp_zip, $taxdmp_url);
 
-# Unzip the downloaded file
 print "Unzipping taxonomy files...\n";
 system('unzip', '-q', $taxdmp_zip, '-d', $taxonomy_files_dir);
 
-# Execute the Python script
 print "Executing Python script...\n";
 my $taxonomy_script = catfile($scripts_dir, 'taxonomy_hierarchy.py');
 system('python3', $taxonomy_script, $taxonomy_files_dir, $data_dir);


### PR DESCRIPTION
## Summary
- allow `config.pl` and `main.pl` to discover bundled helper scripts automatically and fall back to user-defined HYMET_RESOURCES
- write cache, taxonomy and output data into a user-writable HYMET_WORKDIR (defaulting to ~/.hymet) so the commands run from any directory after a Conda install
- document the new runtime directory behaviour and environment variables in the README

## Testing
- perl -c main.pl
- perl -c config.pl

------
https://chatgpt.com/codex/tasks/task_e_68d1f8d426488327828533f284908648